### PR TITLE
Add null handling for some types in APIs

### DIFF
--- a/src/trace/call.hpp
+++ b/src/trace/call.hpp
@@ -47,11 +47,13 @@ public:
     }
 
     uint64_t get(const T& obj) const {
-        if constexpr (std::is_same_v<T, cl_platform_id>) {
+        if constexpr (std::is_same_v<T, cl_platform_id> ||
+                      std::is_same_v<T, cl_context>) {
             if (obj == nullptr) {
                 return -1;
             }
         }
+
         if (m_objects.find(obj) != m_objects.end()) {
             auto val = m_objects.at(obj);
             debug("Object Tracker: getting instance for %p => #%llu\n", obj,

--- a/src/trace/visitor-srcgen.hpp
+++ b/src/trace/visitor-srcgen.hpp
@@ -392,7 +392,12 @@ int main(int argc, char* argv[]) {
                     // Declare var to serve as input parameter
                     if (static_cast<int64_t>(ids[0]) == -1) {
                         assert(ttype ==
-                               CALL_PARAM_TEMPLATE_TYPE_CL_PLATFORM_ID);
+                                   CALL_PARAM_TEMPLATE_TYPE_CL_PLATFORM_ID ||
+                               ttype == CALL_PARAM_TEMPLATE_TYPE_CL_CONTEXT);
+                        pstr = "nullptr";
+                    } else if (ids.empty()) {
+                        assert(ttype == CALL_PARAM_TEMPLATE_TYPE_CL_DEVICE_ID ||
+                               ttype == CALL_PARAM_TEMPLATE_TYPE_CL_EVENT);
                         pstr = "nullptr";
                     } else {
                         auto pvar = makeCallParamVarName(param_num);


### PR DESCRIPTION
Handling for a null context, device or event.

Change-Id: I775920450f9984fd0b7e958c65f86a4132552164