### PR TITLE
Fix map pointers not being erased

### DIFF
--- a/src/trace/call.hpp
+++ b/src/trace/call.hpp
@@ -1036,7 +1036,7 @@ struct Call {
         m_params.push_back(std::make_unique<CallParamMapPointerUse>(id));
     }
 
-    void record_pointer_unmap(void* ptr){
+    void record_pointer_unmap(void* ptr) {
         record_map_pointer_use(ptr);
         gMemObjectMappingTracker.erase(ptr);
     }

--- a/src/trace/cltrace.cpp
+++ b/src/trace/cltrace.cpp
@@ -1103,7 +1103,7 @@ cl_int clEnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
 
     call.record_object_use(command_queue);
     call.record_object_use(memobj);
-    call.record_map_pointer_use(mapped_ptr);
+    call.record_pointer_unmap(mapped_ptr);
     call.record_value(num_events_in_wait_list);
     call.record_object_use(num_events_in_wait_list,
                            const_cast<cl_event*>(event_wait_list));
@@ -1354,7 +1354,7 @@ void clSVMFree(cl_context context, void* svm_pointer) {
 
     Call call(oclapi::command::SVMFREE);
     call.record_object_use(context);
-    call.record_map_pointer_use(svm_pointer); // FIXME
+    call.record_pointer_unmap(svm_pointer); // FIXME
 
     trace.record(call);
 }


### PR DESCRIPTION
The global mem object mapping tracker was not erasing pointers after they have been unmapped. This introduced a bug that meant a map followed by an unmap followed by a map of a different mem object could result in the same address being given out for each map operation. Since the unmap operation did not erase the pointer from the tracker the program would crash.